### PR TITLE
fix: placement of `Disconnect-SsoAdminServer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
 
-## v1.0.0 (Not Released)
+## v1.0.0 (2023-04-25)
 
 - Initial Module Release

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ The module provides coverage for the following components:
 
 ### PowerShell Modules
 
-- [`VMware.PowerCLI`][module-vmware-powercli] 12.7.0 or later
-- [`VMware.vSphere.SsoAdmin`][module-vmware-vsphere-ssoadmin] 1.3.8 or later
+- [`VMware.PowerCLI`][module-vmware-powercli] 13.0.0 or later
+- [`VMware.vSphere.SsoAdmin`][module-vmware-vsphere-ssoadmin] 1.3.9 or later
 - [`PowerVCF`][module-powervcf] 2.2.0 or later
-- [`PowerValidatedSolutions`][module-powervalidatedsolutions] 2.1.0 or later
+- [`PowerValidatedSolutions`][module-powervalidatedsolutions] 2.2.0 or later
 
 ## Installing the Module
 
@@ -58,10 +58,10 @@ Install the supporting PowerShell modules from the PowerShell Gallery by running
 
 ```powershell
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-Module -Name VMware.PowerCLI -MinimumVersion 12.7.0
-Install-Module -Name VMware.vSphere.SsoAdmin -MinimumVersion 1.3.8
+Install-Module -Name VMware.PowerCLI -MinimumVersion 13.0.0
+Install-Module -Name VMware.vSphere.SsoAdmin -MinimumVersion 1.3.9
 Install-Module -Name PowerVCF -MinimumVersion 2.2.0
-Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.1.0
+Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.2.0
 Install-Module -Name VMware.CloudFoundation.PasswordManagement
 ```
 
@@ -75,6 +75,12 @@ Import-Module -Name VMware.vSphere.SsoAdmin
 Import-Module -Name PowerVCF
 Import-Module -Name PowerValidatedSolutions
 Import-Module -Name VMware.CloudFoundation.PasswordManagement
+```
+
+To verify the modules are installed, run the following command in the PowerShell console.
+
+```powershell
+Test-VcfPasswordManagementPrereq
 ```
 
 Once installed, any cmdlets associated with `VMware.CloudFoundation.PasswordManagement` and the supporting PowerShell modules will be available for use.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # PowerShell Module for VMware Cloud Foundation Password Management
 
+[<img src="https://img.shields.io/powershellgallery/v/VMware.CloudFoundation.PasswordManagement?style=for-the-badge&logo=powershell&logoColor=white" alt="PowerShell Gallery">][module-passwordmanagement]&nbsp;&nbsp;
 [<img src="https://img.shields.io/badge/Changelog-Read-blue?style=for-the-badge&logo=github&logoColor=white" alt="CHANGELOG" >][changelog]&nbsp;&nbsp;
+[<img src="https://img.shields.io/powershellgallery/dt/VMware.CloudFoundation.PasswordManagement?style=for-the-badge&logo=powershell&logoColor=white" alt="PowerShell Gallery Downloads">][module-passwordmanagement]&nbsp;&nbsp;
 
 ## Overview
 
@@ -30,7 +32,7 @@ The module provides coverage for the following components:
 
 ### Platforms
 
-- [VMware Cloud Foundation][vmware-cloud-foundation] 4.4 or later
+- [VMware Cloud Foundation][vmware-cloud-foundation] 4.3 or later
 
 ### Operating Systems
 
@@ -54,7 +56,7 @@ The module provides coverage for the following components:
 
 Verify that your system has a supported edition and version of PowerShell installed.
 
-Install the supporting PowerShell modules from the PowerShell Gallery by running the following commands:
+Install the supporting PowerShell modules from the Microsoft PowerShell Gallery by running the following commands in the PowerShell console:
 
 ```powershell
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
@@ -65,9 +67,7 @@ Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.2.0
 Install-Module -Name VMware.CloudFoundation.PasswordManagement
 ```
 
-If using PowerShell Core, import the modules before proceeding:
-
-For example:
+If using PowerShell Core, import the modules by running the following commands in the PowerShell console before proceeding:
 
 ```powershell
 Import-Module -Name VMware.PowerCLI
@@ -77,7 +77,9 @@ Import-Module -Name PowerValidatedSolutions
 Import-Module -Name VMware.CloudFoundation.PasswordManagement
 ```
 
-To verify the modules are installed, run the following command in the PowerShell console.
+## Verifying the Module
+
+To verify the correct versions of the supporting modules are installed, run the following command in the PowerShell console.
 
 ```powershell
 Test-VcfPasswordManagementPrereq
@@ -85,7 +87,23 @@ Test-VcfPasswordManagementPrereq
 
 Once installed, any cmdlets associated with `VMware.CloudFoundation.PasswordManagement` and the supporting PowerShell modules will be available for use.
 
-To view the cmdlets for available in the module, run the following command in the PowerShell console.
+## Updating the Module
+
+Update the PowerShell module to the latest release from the Microsoft PowerShell Gallery by running the following command in the PowerShell console:
+
+```powershell
+Update-Module -Name VMware.CloudFoundation.PasswordManagement
+```
+
+To verify the version of the PowerShell module, run the following command in the PowerShell console.
+
+```powershell
+Get-InstalledModule -Name VMware.CloudFoundation.PasswordManagement
+```
+
+## Getting Help
+
+To view the cmdlets available in the module, run the following command in the PowerShell console.
 
 ```powershell
 Get-Command -Module VMware.CloudFoundation.PasswordManagement
@@ -96,34 +114,24 @@ To view the help for any cmdlet, run the `Get-Help` command in the PowerShell co
 For example:
 
 ```powershell
-Get-Help -Name <cmdlet-name>
+Get-Help -Name Invoke-PasswordPolicyManager
 ```
 
 ```powershell
-Get-Help -Name <cmdlet-name> -Examples
+Get-Help -Name Invoke-PasswordPolicyManager -examples
 ```
 
-## Updating the Module
-
-Update the PowerShell module from the PowerShell Gallery by running the following commands:
-
 ```powershell
-Update-Module -Name VMware.CloudFoundation.PasswordManagement
-```
-
-To verify that the PowerShell module is updated, run the following command in the PowerShell console.
-
-```powershell
-Get-InstalledModule -Name VMware.CloudFoundation.PasswordManagement
+Get-Help -Name Invoke-PasswordPolicyManager -full
 ```
 
 ## User Access
 
 Each cmdlet may provide one or more usage examples. Many of the cmdlets require that credentials are provided to output to the PowerShell console or a report.
 
-The cmdlets in this module, and its dependencies, return data from multple platform components. The credentials for most of the platform components are returned to the cmdlets by retrieving credentials from the SDDC Manager inventory and using these credentials, as needed, within cmdlet operations.
+The cmdlets in this module, and its dependencies, return data from multiple platform components. The credentials for most of the platform components are returned to the cmdlets by retrieving credentials from the SDDC Manager inventory and using these credentials, as needed, within cmdlet operations.
 
-For the best expereince, for cmdlets that connect to SDDC Manager, use the VMware Cloud Foundation API user `admin@local` or an account with the **ADMIN** role in SDDC Manager (e.g., `administrator@vsphere.local`).
+For the best experience, for cmdlets that connect to SDDC Manager, use the VMware Cloud Foundation API user `admin@local` or an account with the **ADMIN** role in SDDC Manager (e.g., `administrator@vsphere.local`).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The module provides coverage for the following components:
 
 - [`VMware.PowerCLI`][module-vmware-powercli] 13.0.0 or later
 - [`VMware.vSphere.SsoAdmin`][module-vmware-vsphere-ssoadmin] 1.3.9 or later
-- [`PowerVCF`][module-powervcf] 2.2.0 or later
+- [`PowerVCF`][module-powervcf] 2.3.0 or later
 - [`PowerValidatedSolutions`][module-powervalidatedsolutions] 2.2.0 or later
 
 ## Installing the Module
@@ -60,7 +60,7 @@ Install the supporting PowerShell modules from the PowerShell Gallery by running
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 Install-Module -Name VMware.PowerCLI -MinimumVersion 13.0.0
 Install-Module -Name VMware.vSphere.SsoAdmin -MinimumVersion 1.3.9
-Install-Module -Name PowerVCF -MinimumVersion 2.2.0
+Install-Module -Name PowerVCF -MinimumVersion 2.3.0
 Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.2.0
 Install-Module -Name VMware.CloudFoundation.PasswordManagement
 ```

--- a/VMware.CloudFoundation.PasswordManagement.psd1
+++ b/VMware.CloudFoundation.PasswordManagement.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.PasswordManagement.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.0.0.1001'
+    ModuleVersion = '1.0.0.1002'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -30,7 +30,7 @@
     Copyright = '(c) 2023 VMware All rights reserved'
     
     # Description of the functionality provided by this module
-    Description = 'A PowerShell module for VMware Cloud Foundation password management.'
+    Description = 'PowerShell Module for VMware Cloud Foundation Password Management'
     
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'

--- a/VMware.CloudFoundation.PasswordManagement.psd1
+++ b/VMware.CloudFoundation.PasswordManagement.psd1
@@ -18,7 +18,7 @@
     # CompatiblePSEditions = @()
     
     # ID used to uniquely identify this module
-    GUID = 'e3d32400-15f4-4882-aa7b-2d82e90ecd20'
+    GUID = 'a3e32400-15f4-4852-aa7b-3d82e90ecd20'
     
     # Author of this module
     Author = 'Gary Blake, Ryan Johnson - Cloud Infrastructure Business Group (CIBG)'

--- a/VMware.CloudFoundation.PasswordManagement.psm1
+++ b/VMware.CloudFoundation.PasswordManagement.psm1
@@ -6272,7 +6272,7 @@ Function Test-VcfPasswordManagementPrereq {
         $modules = @(
             @{ Name=("VMware.PowerCLI"); MinimumVersion=("13.0.0")}
             @{ Name=("VMware.vSphere.SsoAdmin"); MinimumVersion=("1.3.9")}
-            @{ Name=("PowerVCF"); MinimumVersion=("2.2.0")}
+            @{ Name=("PowerVCF"); MinimumVersion=("2.3.0")}
             @{ Name=("PowerValidatedSolutions"); MinimumVersion=("2.2.0")}
         )
 

--- a/VMware.CloudFoundation.PasswordManagement.psm1
+++ b/VMware.CloudFoundation.PasswordManagement.psm1
@@ -1914,8 +1914,7 @@ Function Request-SsoPasswordExpiration {
                                     Write-Error "Unable to retrieve password expiration policy from vCenter Single Sign-On ($($vcfVcenterDetails.fqdn)): PRE_VALIDATION_FAILED"
                                 }
                                 return $SsoPasswordExpirationObject
-                            }
-                            Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
+                            }                            
                         }
                     }
                 } else {
@@ -1925,6 +1924,8 @@ Function Request-SsoPasswordExpiration {
         }
 	} Catch {
         Debug-ExceptionWriter -object $_
+    } Finally {
+        Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
     }
 }
 Export-ModuleMember -Function Request-SsoPasswordExpiration
@@ -1998,7 +1999,6 @@ Function Request-SsoPasswordComplexity {
                                 }
                                 return $SsoPasswordComplexityObject
                             }
-                            Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
 						}
 					}
 				} else {
@@ -2008,7 +2008,9 @@ Function Request-SsoPasswordComplexity {
 		}
 	} Catch {
 		Debug-ExceptionWriter -object $_
-	}
+	} Finally {
+        Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
+    }
 }
 Export-ModuleMember -Function Request-SsoPasswordComplexity
 
@@ -2075,7 +2077,6 @@ Function Request-SsoAccountLockout {
                                 }
                                 return $SsoAccountLockoutObject
                             }
-                            Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
 						}
 					}
 				} else {
@@ -2085,7 +2086,9 @@ Function Request-SsoAccountLockout {
 		}
 	} Catch {
 		Debug-ExceptionWriter -object $_
-	}
+	} Finally {
+        Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
+    }
 }
 Export-ModuleMember -Function Request-SsoAccountLockout
 
@@ -2132,7 +2135,6 @@ Function Update-SsoPasswordExpiration {
                                     Write-Warning "Update Single Sign-On Password Expiration Policy on vCenter Server ($($vcfVcenterDetails.fqdn)), already set: SKIPPED"
                                 }
                             }
-                            Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
                         }
                     }
                 } else {
@@ -2142,6 +2144,8 @@ Function Update-SsoPasswordExpiration {
         }
 	} Catch {
         Debug-ExceptionWriter -object $_
+    } Finally {
+        Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
     }
 }
 Export-ModuleMember -Function Update-SsoPasswordExpiration
@@ -2197,7 +2201,6 @@ Function Update-SsoPasswordComplexity {
                                     Write-Warning "Update Single Sign-On Password Complexity Policy on vCenter Server ($($vcfVcenterDetails.fqdn)), already set: SKIPPED"
                                 }
                             }
-                            Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
                         }
                     }
                 } else {
@@ -2207,6 +2210,8 @@ Function Update-SsoPasswordComplexity {
         }
 	} Catch {
         Debug-ExceptionWriter -object $_
+    } Finally {
+        Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
     }
 }
 Export-ModuleMember -Function Update-SsoPasswordComplexity
@@ -2257,7 +2262,6 @@ Function Update-SsoAccountLockout {
                                     Write-Warning "Update Single Sign-On Account Lockout Policy on vCenter Server ($($vcfVcenterDetails.fqdn)), already set: SKIPPED"
                                 }
                             }
-                            Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
                         }
                     }
                 } else {
@@ -2267,6 +2271,8 @@ Function Update-SsoAccountLockout {
         }
 	} Catch {
         Debug-ExceptionWriter -object $_
+    } Finally {
+        Disconnect-SsoAdminServer -Server $vcfVcenterDetails.fqdn
     }
 }
 Export-ModuleMember -Function Update-SsoAccountLockout

--- a/VMware.CloudFoundation.PasswordManagement.psm1
+++ b/VMware.CloudFoundation.PasswordManagement.psm1
@@ -6271,13 +6271,14 @@ Function Test-VcfPasswordManagementPrereq {
 
         $modules = @(
             @{ Name=("VMware.PowerCLI"); MinimumVersion=("13.0.0")}
+            @{ Name=("VMware.vSphere.SsoAdmin"); MinimumVersion=("1.3.9")}
             @{ Name=("PowerVCF"); MinimumVersion=("2.2.0")}
             @{ Name=("PowerValidatedSolutions"); MinimumVersion=("2.2.0")}
         )
 
         foreach ($module in $modules ) {
             if ((Get-InstalledModule -ErrorAction SilentlyContinue -Name $module.Name).Version -lt $module.MinimumVersion) {
-                $message = "PowerShell Module: $($module.Name) $($module.MinimumVersion) is not installed."
+                $message = "PowerShell Module: $($module.Name) $($module.MinimumVersion) minimum required version is not installed."
                 Show-PasswordManagementOutput -type ERROR -message $message
                 Break
             } else {


### PR DESCRIPTION
Adding DisconnectSSOServers at the right place that is in the finally block

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

    Once we connect to the SSO Admin Servers, we are also doing disconnect to the same to ensure the handles are closed, but at certain places, the disconnect is called after return, because of which they were not getting executed. Having multiple handles resulted in displaying the data multiple times  


**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix. 
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #20 

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
