### PR TITLE
feat: add sddcmanager expiration cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 > Release Date: Unreleased
 
+Enhancement:
+
+- Added `Request-SddcManagerPasswordExpiration` cmdlet to retrieve the password expiration policy for the default local users on an SDDC Manager appliance. [GH-97](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/97)
+- Added `Update-SddcManagerPasswordExpiration` cmdlet to update the password expiration policy for the default local users on an SDDC Manager appliance. [GH-97](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/97)
+
 Bug Fixes:
 
 - Updated `Get-PasswordPolicyDefault` to include support for version 4.4.1. [GH-95](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/95)

--- a/docs/documentation/functions/Request-SddcManagerPasswordExpiration.md
+++ b/docs/documentation/functions/Request-SddcManagerPasswordExpiration.md
@@ -1,0 +1,163 @@
+# Request-SddcManagerPasswordExpiration
+
+## Synopsis
+
+Retrieves the password expiration policy for an SDDC Manager.
+
+## Syntax
+
+```powershell
+Request-SddcManagerPasswordExpiration -server <String> -user <String> -pass <String> -rootPass <String> [-drift] [-reportPath <String>] [-policyFile <String>] [<CommonParameters>]
+```
+
+## Description
+
+The `Request-SddcManagerPasswordExpiration` cmdlet retrieves the password expiration policy for an SDDC Manager.
+The cmdlet connects to SDDC Manager using the `-server`, `-user`, and `-pass` values:
+
+- Validates that network connectivity and authentication is possible to SDDC Manager
+- Retrieves the password expiration policy
+
+## Examples
+
+### Example 1
+
+```powershell
+Request-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
+```
+
+This example retrieves the password expiration policy for an SDDC Manager.
+
+### Example 2
+
+```powershell
+Request-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1! -drift -reportPath "F:\Reporting" -policyFile "passwordPolicyConfig.json"
+```
+
+This example retrieves the password expiration policy for an SDDC Manager and compares the configuration against passwordPolicyConfig.json.
+
+### Example 3
+
+```powershell
+Request-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1! -drift
+```
+
+This example retrieves the password expiration policy for an SDDC Manager and compares the configuration against the product defaults.
+
+## Parameters
+
+### -server
+
+The fully qualified domain name of the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The username to authenticate to the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The password to authenticate to the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -rootPass
+
+The password for the SDDC Manager appliance root account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -drift
+
+Switch to compare the current configuration against the product defaults or a JSON file.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -reportPath
+
+The path to save the policy report.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -policyFile
+
+The path to the password policy file to compare against.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/Update-LocalUserPasswordExpiration.md
+++ b/docs/documentation/functions/Update-LocalUserPasswordExpiration.md
@@ -27,7 +27,7 @@ The cmdlet connects to SDDC Manager using the `-server`, `-user`, and `-pass` va
 Update-LocalUserPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -domain sfo-m01 -vmName sfo-wsa01 -guestUser root -guestPassword VMw@re1! -localUser "root","sshuser" -minDays 0 -maxDays 999 -warnDays 14
 ```
 
-This example updates the global password expiration policy for a vCenter Server instance.
+This example updates the password expiration policy for the specified local users on the specified virtual machine.
 
 ## Parameters
 

--- a/docs/documentation/functions/Update-SddcManagerPasswordExpiration.md
+++ b/docs/documentation/functions/Update-SddcManagerPasswordExpiration.md
@@ -1,0 +1,148 @@
+# Update-SddcManagerPasswordExpiration
+
+## Synopsis
+
+Updates the password expiration policy for an SDDC Manager.
+
+## Syntax
+
+```powershell
+Update-SddcManagerPasswordExpiration [-server] <String> [-user] <String> [-pass] <String> [-rootPass] <String> [-minDays] <String> [-maxDays] <String> [-warnDays] <String> [[-detail] <String>] [<CommonParameters>]
+```
+
+## Description
+
+The `Update-SddcManagerPasswordExpiration` cmdlet configures the password expiration policy for an SDDC Manager.
+The cmdlet connects to SDDC Manager using the `-server`, `-user`, and `-pass` values:
+
+- Validates that network connectivity and authentication is possible to SDDC Manager
+- Configures the password expiration policy
+
+## Examples
+
+### Example 1
+
+```powershell
+Update-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1! -minDays 0 -maxDays 90 -warnDays 14
+```
+
+This example updates the password expiration policy for the default local users on an SDDC Manager.
+
+## Parameters
+
+### -server
+
+The fully qualified domain name of the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The username to authenticate to the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The password to authenticate to the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -rootPass
+
+The password for the SDDC Manager appliance root account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -minDays
+
+The minimum number of days before the password expires.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: 0
+Accept pipeline input: False
+Accept wil
+
+### -maxDays
+
+The maximum number of days before the password expires.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -detail
+
+Return the details of the policy.
+One of true or false.
+Default is true.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,8 @@ nav:
     - Password Expiration:
       - SDDC Manager:
         - Publish-SddcManagerPasswordExpiration: documentation/functions/Publish-SddcManagerPasswordExpiration.md
+        - Request-SddcManagerPasswordExpiration: documentation/functions/Request-SddcManagerPasswordExpiration.md
+        - Update-SddcManagerPasswordExpiration: documentation/functions/Update-SddcManagerPasswordExpiration.md
       - vCenter Server:
         - Publish-VcenterLocalPasswordExpiration: documentation/functions/Publish-VcenterLocalPasswordExpiration.md
         - Publish-VcenterPasswordExpiration: documentation/functions/Publish-VcenterPasswordExpiration.md


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

- Added `Request-SddcManagerPasswordExpiration` cmdlet and docs to retrieve the password expiration policy for the default local users on an SDDC Manager appliance.
- Added `Update-SddcManagerPasswordExpiration` cmdlet and docs to update the password expiration policy for the default local users on an SDDC Manager appliance.
- Updated module version and build to v1.4.0.1000.
- Updated `CHANGELOG.md`.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

```powershell
PS F:\VMware.CloudFoundation.PasswordManagement> Request-VcfToken

cmdlet Request-VCFToken at command pipeline position 1
Supply values for the following parameters:
fqdn: sfo-vcf01.sfo.rainpole.io

PowerShell credential request
Enter your credentials.
User: administrator@vsphere.local
Password for user administrator@vsphere.local: **********

Successfully Requested New API Token From SDDC Manager: sfo-vcf01.sfo.rainpole.io

PS F:\VMware.CloudFoundation.PasswordManagement> Request-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -rootPass VMw@re123!

Workload Domain : sfo-m01
System          : sfo-vcf01
User            : root
Min Days        : 0
Max Days        : 90
Warning Days    : 7

Workload Domain : sfo-m01
System          : sfo-vcf01
User            : vcf
Min Days        : 0
Max Days        : 90
Warning Days    : 7

Workload Domain : sfo-m01
System          : sfo-vcf01
User            : backup
Min Days        : 0
Max Days        : 90
Warning Days    : 7

PS F:\VMware.CloudFoundation.PasswordManagement> Update-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -rootPass VMw@re123! -minDays 0 -maxDays 90 -warnDays 14

Update Local User (root) Password Expiration Policy on Virtual Machine (sfo-vcf01): SUCCESSFUL
Update Local User (vcf) Password Expiration Policy on Virtual Machine (sfo-vcf01): SUCCESSFUL
Update Local User (backup) Password Expiration Policy on Virtual Machine (sfo-vcf01): SUCCESSFUL

PS F:\VMware.CloudFoundation.PasswordManagement> Request-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -rootPass VMw@re123!

Workload Domain : sfo-m01
System          : sfo-vcf01
User            : root
Min Days        : 0
Max Days        : 90
Warning Days    : 14

Workload Domain : sfo-m01
System          : sfo-vcf01
User            : vcf
Min Days        : 0
Max Days        : 90
Warning Days    : 14

Workload Domain : sfo-m01
System          : sfo-vcf01
User            : backup
Min Days        : 0
Max Days        : 90
Warning Days    : 14


PS F:\VMware.CloudFoundation.PasswordManagement> Update-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -rootPass VMw@re123! -minDays 0 -maxDays 90 -warnDays 14

WARNING: Update Local User (root) Password Expiration Policy on Virtual Machine (sfo-vcf01), already set: SKIPPED
WARNING: Update Local User (vcf) Password Expiration Policy on Virtual Machine (sfo-vcf01), already set: SKIPPED
WARNING: Update Local User (backup) Password Expiration Policy on Virtual Machine (sfo-vcf01), already set: SKIPPED

PS F:\VMware.CloudFoundation.PasswordManagement> Update-SddcManagerPasswordExpiration -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -rootPass VMw@re123! -minDays 0 -maxDays 90 -warnDays 14 -detail false

Update Local Users to Max Days (90), Min Days (0) and Warn Days (14) on Virtual Machine (sfo-vcf01): SUCCESSFUL
```

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

Closes #70 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
