### PR TITLE
fix: esxi password complexity policy validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug Fixes:
 - Updated `Get-PasswordPolicyDefault` to include support for version 4.4.1. [GH-95](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/95)
 - Updated `Get-PasswordPolicyConfig` to include support for version 4.4.1. [GH-95](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/95)
 - Updated `Invoke-PasswordPolicyManager`, `Start-PasswordPolicyConfig`, and `Get-PasswordPolicyConfig` to better handle use of `Test-Path` and `Get-Content` cmdlets when verifing and consuming the password policy configuration JSON file. [GH-98](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/98)
+- Updated `Test-PasswordPolicyConfig` to better handle validation of ESXi host password complexity policy in the password policy configuration JSON file. [GH-99](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/99)
 
 ## [v1.3.0](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/releases/tag/v1.3.0)
 

--- a/VMware.CloudFoundation.PasswordManagement.psd1
+++ b/VMware.CloudFoundation.PasswordManagement.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.PasswordManagement.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.0.1001'
+    ModuleVersion = '1.4.0.1002'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

- Updated `Test-PasswordPolicyConfig` to better handle validation of ESXi host password complexity policy in the password policy configuration JSON file.
- Minor error message updates.
- Updated module version and build to v1.4.0.1002.
- Updated `CHANGELOG.md`.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

Out of Range:

```powershell
Write-Error: The recommended range for esxi:passwordComplexity:policy should be between 7 and 999. [0]
Write-Error: The recommended range for esxi:passwordComplexity:policy should be between 7 and 999. [99999]
Write-Error: Validation errors found in the password policy configuration file. Review the password policy configuration file and retry.
Get-PasswordPolicyConfig: Validation of Password Policy Configuration File: FAILED
```

In Range:

```powershell
 [08-23-2023_09:01:41] INFO Starting the Process of Generating Password Policy Manager Report for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:01:41] INFO Setting up the log file to path F:\Reporting\logs\Invoke-PasswordPolicyManager-08-23-2023_09_01_41.log.
 [08-23-2023_09:01:41] INFO Setting up report folder and report F:\Reporting\PasswordPolicyManager\08-23-2023_09_01_41-passwordPolicyManager-sfo-vcf01.htm.
 [08-23-2023_09:01:41] INFO Collecting SDDC Manager Password Policies for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:02:30] INFO Collecting vCenter Single Sign-On Password Policies for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:02:40] INFO Collecting vCenter Server Password Expiration Policy for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:02:46] INFO Collecting vCenter Server (Local User) Password Policies for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:03:44] INFO Collecting NSX Manager Password Policies for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:04:44] INFO Collecting NSX Edge Password Policies for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:05:47] INFO Collecting ESXi Password Policies for VMware Cloud Foundation instance (sfo-vcf01.sfo.rainpole.io).
 [08-23-2023_09:06:32] INFO Generating the Final Report and Saving to (F:\Reporting\PasswordPolicyManager\08-23-2023_09_01_41-passwordPolicyManager-sfo-vcf01.htm).
PS F:\VMware.CloudFoundation.PasswordManagement>
```

![image](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/assets/7771363/d24325c2-b9a3-4c78-9b1b-e1b8b071a9b3)

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

Closes #88

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
