### PR TITLE
feat: add support password rotation report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## v1.5.0 (Unreleased)
+
+Enhancement:
+
+- Added `Invoke-PasswordRotationManager`, `Save-ClarityReportNavigationForRotation` and `Set-CreateReportDirectoryRotation` cmdlets and updated `Publish-PasswordRotationPolicy` cmdlet to generate report for password rotation settings for accounts managed by SDDC Manager in HTML or JSON format. Results can be filtered by workload domain. [GH-115](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/115) 
+- Updated `Invoke-PasswordPolicyManager`, `Get-PasswordPolicyDefault`, `Get-PasswordPolicyConfig`, `Request-SddcManagerPasswordComplexity`, `Request-SddcManagerAccountLockout`, `Request-SsoAccountLockout`, `Request-VcenterPasswordExpiration`, `Request-VcenterPasswordComplexity`, `Request-VcenterAccountLockout`, `Request-VcenterRootPasswordExpiration`, `Request-NsxtManagerPasswordExpiration`, `Request-NsxtManagerPasswordComplexity`, `Request-NsxtManagerAccountLockout`, `Request-NsxtEdgePasswordExpiration`, `Request-NsxtEdgePasswordComplexity`, `Request-NsxtEdgeAccountLockout`, `Request-EsxiPasswordExpiration`, `Request-EsxiPasswordComplexity`, `Request-EsxiAccountLockout` and `Request-LocalUserPasswordExpiration` cmdlet to simplify the logic for reading version information. [GH-115](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/115)
+
+
 ## [v1.4.0](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/releases/tag/v1.4.0)
 
 > Release Date: 2023-08-29

--- a/VMware.CloudFoundation.PasswordManagement.psd1
+++ b/VMware.CloudFoundation.PasswordManagement.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.PasswordManagement.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.0.1004'
+    ModuleVersion = '1.5.0.1000'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/VMware.CloudFoundation.PasswordManagement.psm1
+++ b/VMware.CloudFoundation.PasswordManagement.psm1
@@ -41,6 +41,281 @@ if ($PSEdition -eq 'Desktop') {
 }
 
 ##########################################################################
+#Region     Begin Password Rotation Manager Functions                 ######
+
+Function Invoke-PasswordRotationManager {
+    <#
+        .SYNOPSIS
+        Generates a Password Rotation Manager Report for a workload domain or all workload domains.
+
+        .DESCRIPTION
+        The Invoke-PasswordRotationManager generates a Password Rotation Manager Report for a VMware Cloud Foundation instance.
+
+        .EXAMPLE
+        Invoke-PasswordRotationManager -sddcManagerFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerUser admin@local -sddcManagerPass VMw@re1!VMw@re1! -reportPath "F:\Reporting" -darkMode -allDomains
+        This example runs a password rotation report for all workload domains within an SDDC Manager instance.
+
+        .EXAMPLE
+        Invoke-PasswordRotationManager -sddcManagerFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerUser admin@local -sddcManagerPass VMw@re1!VMw@re1!  -reportPath "F:\Reporting" -darkMode -workloadDomain sfo-w01
+        This example runs a password rotation report for a specific Workload Domain within an SDDC Manager instance.
+
+        .PARAMETER sddcManagerFqdn
+        The fully qualified domain name of the SDDC Manager instance.
+
+        .PARAMETER sddcManagerUser
+        The username to authenticate to the SDDC Manager instance.
+
+        .PARAMETER sddcManagerPass
+        The password to authenticate to the SDDC Manager instance.
+
+        .PARAMETER sddcRootPass
+        The password for the SDDC Manager appliance root account.
+
+        .PARAMETER reportPath
+        The path to save the report to.
+
+        .PARAMETER allDomains
+        Switch to run the report for all workload domains.
+
+        .PARAMETER workloadDomain
+        Switch to run the report for a specific workload domain.
+
+        .PARAMETER darkMode
+        Switch to use dark mode for the report.
+
+        .PARAMETER json
+        Switch to output the report in JSON format.
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$sddcManagerFqdn,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$sddcManagerUser,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$sddcManagerPass,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$sddcRootPass,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$reportPath,
+        [Parameter (ParameterSetName = 'All-WorkloadDomains', Mandatory = $true)] [ValidateNotNullOrEmpty()] [Switch]$allDomains,
+        [Parameter (ParameterSetName = 'Specific-WorkloadDomain', Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$workloadDomain,
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [Switch]$darkMode,
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [Switch]$json
+    )
+
+    Try {
+
+        Clear-Host; Write-Host ""
+
+        if (Test-VCFConnection -server $sddcManagerFqdn) {
+            if (Test-VCFAuthentication -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass) {
+                $version = Get-VCFManager -version
+                if ($reportPath.EndsWith("\") -or $reportPath.EndsWith("/")) {
+                    $reportPath = $reportPath.TrimEnd("\", "/")
+                }
+                if (!(Test-Path -Path $reportPath)) {Write-Warning "Unable to locate report path $reportPath. Enter a valid path and retry."; Write-Host ""; Break }
+                Start-SetupLogFile -Path $reportPath -ScriptName $MyInvocation.MyCommand.Name # Setup Log Location and Log File
+                $defaultReport = Set-CreateReportDirectoryRotation -path $reportPath -sddcManagerFqdn $sddcManagerFqdn # Setup Report Location and Report File
+                if ($PsBoundParameters.ContainsKey("allDomains")) {
+                    $reportname = $defaultReport.Split('.')[0] + "-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
+                    $workflowMessage = "VMware Cloud Foundation instance ($sddcManagerFqdn)"
+                    $commandSwitch = "-allDomains"
+                } else {
+                    $reportname = $defaultReport.Split('.')[0] + "-" + $workloadDomain + ".htm"
+                    $workflowMessage = "Workload Domain ($workloadDomain)"
+                    $commandSwitch = "-workloadDomain $workloadDomain"
+                }
+                if ($PsBoundParameters.ContainsKey("json")) {
+                    $commandSwitch = $commandSwitch + " -json"
+                    Write-LogMessage -Type INFO -Message "Starting the Process of Generating Password Rotation Manager JSON for $workflowMessage." -Colour Yellow
+                } else {
+                    Write-LogMessage -Type INFO -Message "Starting the Process of Generating Password Rotation Manager Report for $workflowMessage." -Colour Yellow
+                    Write-LogMessage -Type INFO -Message "Setting up the log file to path $logfile."
+                    Write-LogMessage -Type INFO -Message "Setting up report folder and report $reportName."
+                }
+
+                
+                if ($PsBoundParameters.ContainsKey("json")) {
+
+                    # Collect Password Rotation Setting Data
+                    Write-LogMessage -Type INFO -Message "Collecting SDDC Manager Password Rotation for $workflowMessage."
+                    $sddcManagerPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'backup' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting vCenter Server Single Sign-On Rotation for $workflowMessage."
+                    $ssoPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'sso' $($commandSwitch)" | convertfrom-json
+
+                    Write-LogMessage -Type INFO -Message "Collecting vCenter Server Password Rotation for $workflowMessage."
+                    $vcenterServerPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'vcenterServer' $($commandSwitch)" | convertfrom-json
+
+                    Write-LogMessage -Type INFO -Message "Collecting NSX Manager Password Rotation for $workflowMessage."
+                    $nsxManagerPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'nsxManager' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting NSX Edge Password Rotation for $workflowMessage."
+                    $nsxEdgePasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'nsxEdge' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting WorkSpace ONE Access Password Rotation for $workflowMessage."
+                    $wsaPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'workspaceOneAccess' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Automation Password Rotation for $workflowMessage."
+                    $ariaAutomationPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaAutomation' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Operations Password Rotation for $workflowMessage."
+                    $ariaOperationsPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaOperations' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Operations Logs Password Rotation for $workflowMessage."
+                    $ariaOperationsLogsPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaOperationsLogs' $($commandSwitch)" | convertfrom-json
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Suite Lifecycle Password Rotation for $workflowMessage."
+                    $ariaLifecyclePasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaLifecycle' $($commandSwitch)" | convertfrom-json
+                    
+                    # Add VCF version into JSON file
+                    $vcfVersion = New-Object -TypeName psobject
+                    $vcfVersion | Add-Member -notepropertyname 'vcfVersion' -notepropertyvalue $version
+
+                    $sddcManagerPasswordRotationObj = New-Object -TypeName psobject
+                    $sddcManagerPasswordRotationObj | Add-Member -notepropertyname 'sddcManager' -notepropertyvalue $sddcManagerPasswordRotation
+
+                    $ssoPasswordRotationObj = New-Object -TypeName psobject
+                    $ssoPasswordRotationObj | Add-Member -notepropertyname 'sso' -notepropertyvalue $ssoPasswordRotation
+
+                    $vcenterServerPasswordRotationObj = New-Object -TypeName psobject
+                    $vcenterServerPasswordRotationObj | Add-Member -notepropertyname 'vcenterServer' -notepropertyvalue $vcenterServerPasswordRotation
+
+                    $nsxManagerPasswordRotationObj = New-Object -TypeName psobject
+                    $nsxManagerPasswordRotationObj | Add-Member -notepropertyname 'nsxManager' -notepropertyvalue $nsxManagerPasswordRotation
+
+                    $nsxEdgePasswordRotationObj = New-Object -TypeName psobject
+                    $nsxEdgePasswordRotationObj | Add-Member -notepropertyname 'nsxEdge' -notepropertyvalue $nsxEdgePasswordRotation
+                    
+                    $wsaPasswordRotationObj = New-Object -TypeName psobject
+                    $wsaPasswordRotationObj | Add-Member -notepropertyname 'wsa' -notepropertyvalue $wsaPasswordRotation
+
+                    $ariaAutomationPasswordRotationObj = New-Object -TypeName psobject
+                    $ariaAutomationPasswordRotationObj | Add-Member -notepropertyname 'ariaAutomation' -notepropertyvalue $ariaAutomationPasswordRotation
+
+                    $ariaOperationsPasswordRotationObj = New-Object -TypeName psobject
+                    $ariaOperationsPasswordRotationObj | Add-Member -notepropertyname 'ariaOperations' -notepropertyvalue $ariaOperationsPasswordRotation
+
+                    $ariaOperationsLogsPasswordRotationObj = New-Object -TypeName psobject
+                    $ariaOperationsLogsPasswordRotationObj | Add-Member -notepropertyname 'ariaOperationsLogs' -notepropertyvalue $ariaOperationsLogsPasswordRotation
+
+                    $ariaLifecyclePasswordRotationObj = New-Object -TypeName psobject
+                    $ariaLifecyclePasswordRotationObj | Add-Member -notepropertyname 'ariaLifecycle' -notepropertyvalue $ariaLifecyclePasswordRotation
+
+                    # Build Final Default Password Rotation Object
+                    $outputJsonObject = New-Object -TypeName psobject
+                    $outputJsonObject | Add-Member -notepropertyname 'vcf' -notepropertyvalue $vcfVersion
+                    $outputJsonObject | Add-Member -notepropertyname 'sddcManager' -notepropertyvalue $sddcManagerPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'sso' -notepropertyvalue $ssoPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'vcenterServer' -notepropertyvalue $vcenterServerPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'nsxManager' -notepropertyvalue $nsxManagerPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'nsxEdge' -notepropertyvalue $nsxEdgePasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'wsa' -notepropertyvalue $wsaPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'ariaAutomation' -notepropertyvalue $ariaAutomationPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'ariaOperations' -notepropertyvalue $ariaOperationsPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'ariaOperationsLogs' -notepropertyvalue $ariaOperationsLogsPasswordRotation
+                    $outputJsonObject | Add-Member -notepropertyname 'ariaLifecycle' -notepropertyvalue $ariaLifecyclePasswordRotation
+                    $jsonFile = ($reportFolder + "passwordRotationManager" + ".json")
+                    Write-LogMessage -Type INFO -Message "Generating the Final JSON and Saving to ($jsonFile)."
+                    $outputJsonObject | ConvertTo-Json -Depth 25| Out-File -FilePath $jsonFile
+                } else {
+
+                    # Collect Password Rotation Setting Data
+                    Write-LogMessage -Type INFO -Message "Collecting SDDC Manager Password Rotation for $workflowMessage."
+                    $sddcManagerPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'backup' $($commandSwitch)" 
+
+                    Write-LogMessage -Type INFO -Message "Collecting vCenter Server Single Sign On Rotation for $workflowMessage."
+                    $ssoPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'sso' $($commandSwitch)" 
+
+                    Write-LogMessage -Type INFO -Message "Collecting vCenter Server Password Rotation for $workflowMessage."
+                    $vcenterServerPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'vcenterServer' $($commandSwitch)" 
+
+                    Write-LogMessage -Type INFO -Message "Collecting NSX Manager Password Rotation for $workflowMessage."
+                    $nsxManagerPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'nsxManager' $($commandSwitch)" 
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting NSX Edge Password Rotation for $workflowMessage."
+                    $nsxEdgePasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'nsxEdge' $($commandSwitch)" 
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting WorkSpace ONE Access Password Rotation for $workflowMessage."
+                    $wsaPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'workspaceOneAccess' $($commandSwitch)" 
+
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Automation Password Rotation for $workflowMessage."
+                    $ariaAutomationPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaAutomation' $($commandSwitch)" 
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Operations Password Rotation for $workflowMessage."
+                    $ariaOperationsPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaOperations' $($commandSwitch)" 
+
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Operations Logs Password Rotation for $workflowMessage."
+                    $ariaOperationsLogsPasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaOperationsLogs' $($commandSwitch)" 
+                    
+                    Write-LogMessage -Type INFO -Message "Collecting Aria Suite Lifecycle Password Rotation for $workflowMessage."
+                    $ariaLifecyclePasswordRotation = Invoke-Expression "Publish-PasswordRotationPolicy -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -resource 'ariaLifecycle' $($commandSwitch)" 
+                    
+                    # Combine all information gathered into a single HTML report
+                    if ($PsBoundParameters.ContainsKey("allDomains")) {
+                        $reportData = "<h1>SDDC Manager: $sddcManagerFqdn</h1>"
+                    } else{
+                        $reportData = "<h1>Workload Domain: $workloadDomain</h1>"
+                    }
+                    if ($sddcManagerPasswordRotation.Count -gt 3) {
+                        $reportData += $sddcManagerPasswordRotation
+                    }
+                    if ($ssoPasswordRotation.Count -gt 3) {
+                        $reportData += $ssoPasswordRotation
+                    }
+                    if ($vcenterServerPasswordRotation.Count -gt 3) {
+                        $reportData += $vcenterServerPasswordRotation
+                    }
+                    if ($nsxManagerPasswordRotation.Count -gt 3) {
+                        $reportData += $nsxManagerPasswordRotation
+                    }
+                    if ($nsxEdgePasswordRotation.Count -gt 3) {
+                        $reportData += $nsxEdgePasswordRotation
+                    }
+                    if ($ariaLifecyclePasswordRotation.Count -gt 3) {
+                        $reportData += $ariaLifecyclePasswordRotation
+                    }
+                    if ($ariaOperationsLogsPasswordRotation.Count -gt 3) {                        
+                        $reportData += $ariaOperationsLogsPasswordRotation
+                    }
+                    if ($ariaOperationsPasswordRotation.Count -gt 3) {
+                        $reportData += $ariaOperationsPasswordRotation
+                    }
+                    if ($ariaAutomationPasswordRotation.Count -gt 3) {
+                        $reportData += $ariaAutomationPasswordRotation
+                    }
+                    if ($wsaPasswordRotation.Count -gt 3) {
+                        $reportData += $wsaPasswordRotation
+                    }
+
+                    if ($PsBoundParameters.ContainsKey("darkMode")) {
+                        $reportHeader = Save-ClarityReportHeader -dark
+                    } else {
+                        $reportHeader = Save-ClarityReportHeader
+                    }
+                    $reportNavigation = Save-ClarityReportNavigationForRotation
+                    $reportFooter = Save-ClarityReportFooter
+
+                    $report = $reportHeader
+                    $report += $reportNavigation
+                    $report += $reportData
+                    $report += $reportFooter
+                    
+                    # Generate the report to an HTML file and then open it in the default browser
+                    Write-LogMessage -Type INFO -Message "Generating the Final Report and Saving to ($reportName)."
+                    $report | Out-File $reportName
+                    if ($PSEdition -eq "Core" -and ($PSVersionTable.OS).Split(' ')[0] -ne "Linux") {
+                        Invoke-Item $reportName
+                    } elseif ($PSEdition -eq "Desktop") {
+                        Invoke-Item $reportName
+                    }
+                }
+            }
+        }
+    } Catch {
+        Debug-CatchWriter -object $_
+    }
+}
+Export-ModuleMember -Function Invoke-PasswordRotationManager
+
+
+##########################################################################
 #Region     Begin Password Policy Manager Functions                 ######
 
 Function Invoke-PasswordPolicyManager {
@@ -137,10 +412,7 @@ Function Invoke-PasswordPolicyManager {
 
         if (Test-VCFConnection -server $sddcManagerFqdn) {
             if (Test-VCFAuthentication -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass) {
-                $version = ""
-                if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                    $version = $Matches[0]
-                }
+                $version = Get-VCFManager -version
                 if ($reportPath.EndsWith("\") -or $reportPath.EndsWith("/")) {
                     $reportPath = $reportPath.TrimEnd("\", "/")
                 }
@@ -352,6 +624,7 @@ Function Invoke-PasswordPolicyManager {
     }
 }
 Export-ModuleMember -Function Invoke-PasswordPolicyManager
+
 
 Function Start-PasswordPolicyConfig {
     <#
@@ -618,7 +891,7 @@ Function Get-PasswordPolicyDefault {
 
     Param (
         [Parameter (Mandatory = $false, ParameterSetName = 'json')] [ValidateNotNullOrEmpty()] [Switch]$generateJson,
-        [Parameter (Mandatory = $true)] [ValidateSet('4.4.0','4.4.1','4.5.0','4.5.1','4.5.2','5.0.0')] [String]$version,
+        [Parameter (Mandatory = $true)] [ValidateSet('4.4.0.0','4.4.1.0','4.5.0.0','4.5.1.0','4.5.2.0','5.0.0.0')] [String]$version,
         [Parameter (Mandatory = $true, ParameterSetName = 'json')] [ValidateNotNullOrEmpty()] [String]$jsonFile,
         [Parameter (Mandatory = $false, ParameterSetName = 'json')] [ValidateNotNullOrEmpty()] [Switch]$force
     )
@@ -857,7 +1130,7 @@ Export-ModuleMember -Function Get-PasswordPolicyDefault
 Function Get-PasswordPolicyConfig {
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$reportPath,
-        [Parameter (Mandatory = $true)] [ValidateSet('4.4.0','4.4.1','4.5.0','4.5.1','4.5.2','5.0.0')] [String]$version,
+        [Parameter (Mandatory = $true)] [ValidateSet('4.4.0.0','4.4.1.0','4.5.0.0','4.5.1.0','4.5.2.0','5.0.0.0')] [String]$version,
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$policyFile
     )
 
@@ -1212,6 +1485,24 @@ Function Set-CreateReportDirectory {
     $reportName
 }
 
+Function Set-CreateReportDirectoryRotation {
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$path,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$sddcManagerFqdn
+    )
+
+    $filetimeStamp = Get-Date -Format "MM-dd-yyyy_hh_mm_ss"
+    $Global:reportFolder = join-path -Path $path -ChildPath 'PasswordRotationManager\'
+    if ($PSEdition -eq "Core" -and ($PSVersionTable.OS).Split(' ')[0] -eq "Linux") {
+        $reportFolder = ($reportFolder).split('\') -join '/' | Split-Path -NoQualifier
+    }
+    if (!(Test-Path -Path $reportFolder)) {
+        New-Item -Path $reportFolder -ItemType "directory" | Out-Null
+    }
+    $reportName = $reportFolder + $filetimeStamp + "-passwordRotationManager" + ".htm"
+    $reportName
+}
+
 Function Save-ClarityReportHeader {
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [Switch]$dark
@@ -1410,6 +1701,41 @@ Function Save-ClarityReportHeader {
     $clarityCssHeader
 }
 
+Function Save-ClarityReportNavigationForRotation {
+    $clarityCssNavigation = '
+        <nav class="subnav">
+        <ul class="nav">
+        <li class="nav-item">
+            <a class="nav-link active" href="">Password Rotation Manager</a>
+        </li>
+        </ul>
+        </nav>
+        <div class="content-container">
+        <nav class="sidenav">
+        <section class="sidenav-content">
+            <section class="nav-group collapsible">
+                <input id="rotation" type="checkbox"/>
+                <label for="rotation">Password Rotation</label>
+                <ul class="nav-list">
+                    <li><a class="nav-link" href="#sddc-manager-password-rotation">SDDC Manager</a></li>
+                    <li><a class="nav-link" href="#vcenter-single-sign-on-password-rotation">vCenter Single Sign-On</a></li>
+                    <li><a class="nav-link" href="#vcenter-server-password-rotation">vCenter Server</a></li>
+                    <li><a class="nav-link" href="#nsx-manager-password-rotation">NSX Manager</a></li>
+                    <li><a class="nav-link" href="#nsx-edge-password-rotation">NSX Edge</a></li>
+                    <li><a class="nav-link" href="#aria-suite-lifecycle-password-rotation">Aria Suite Lifecycle</a></li>
+                    <li><a class="nav-link" href="#aria-operations-for-logs-password-rotation">Aria Operations for Logs</a></li>
+                    <li><a class="nav-link" href="#aria-operations-password-rotation">Aria Operations</a></li>
+                    <li><a class="nav-link" href="#aria-automation-password-rotation">Aria Automation</a></li>
+                    <li><a class="nav-link" href="#workspace-one-access-password-rotation">Workspace ONE Access</a></li>
+                </ul>
+            </section>
+        </section>
+        </nav>
+            <div class="content-area">
+                <div class="content-area">'
+    $clarityCssNavigation
+}
+
 Function Save-ClarityReportNavigation {
     $clarityCssNavigation = '
             <nav class="subnav">
@@ -1489,11 +1815,21 @@ Function Convert-CssClassStyle {
     )
 
     # Function to replace CSS Style
+    # Function to replace Alerts with colour coded CSS Style
+    $oldAlertOK = '<td>GREEN</td>'
+    $newAlertOK = '<td class="alertOK">GREEN</td>'
+    $oldAlertCritical = '<td>RED</td>'
+    $newAlertCritical = '<td class="alertCritical">RED</td>'
+    $oldAlertWarning = '<td>YELLOW</td>'
+    $newAlertWarning = '<td class="alertWarning">YELLOW</td>'
     $oldTable = '<table>'
     $newTable = '<table class="table">'
     $oldAddLine = ':-: '
     $newNewLine = '<br/>'
 
+    $htmlData = $htmlData -replace $oldAlertOK,$newAlertOK
+    $htmlData = $htmlData -replace $oldAlertCritical,$newAlertCritical
+    $htmlData = $htmlData -replace $oldAlertWarning,$newAlertWarning
     $htmlData = $htmlData -replace $oldTable,$newTable
     $htmlData = $htmlData -replace $oldAddLine,$newNewLine
     $htmlData
@@ -1651,10 +1987,7 @@ Function Request-SddcManagerPasswordComplexity {
                     if (Test-vSphereConnection -server $($vcfVcenterDetails.fqdn)) {
                         if (Test-vSphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
                             if ($drift) {
-                                $version = ""
-                                if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                                    $version = $Matches[0]
-                                } 
+                                $version = Get-VCFManager -version
                                 if ($PsBoundParameters.ContainsKey('policyFile')) {
                                     Get-LocalPasswordComplexity -version $version -vmName ($server.Split("."))[-0] -guestUser root -guestPassword $rootPass -product sddcManager -drift -reportPath $reportPath -policyFile $policyFile
                                 } else {
@@ -1741,10 +2074,7 @@ Function Request-SddcManagerAccountLockout {
                     if (Test-vSphereConnection -server $($vcfVcenterDetails.fqdn)) {
                         if (Test-vSphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
                             if ($drift) {
-                                $version = ""
-                                if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                                    $version = $Matches[0]
-                                } 
+                                $version = Get-VCFManager -version
                                 if ($PsBoundParameters.ContainsKey('policyFile')) {
                                     Get-LocalAccountLockout -version $version -vmName ($server.Split("."))[-0] -guestUser root -guestPassword $rootPass -product sddcManager -drift -reportPath $reportPath -policyFile $policyFile
                                 } else {
@@ -2449,10 +2779,7 @@ Function Request-SsoPasswordExpiration {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey("policyFile")) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).sso.passwordExpiration
                     } else {
@@ -2565,10 +2892,7 @@ Function Request-SsoPasswordComplexity {
 		if (Test-VCFConnection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {              
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey("policyFile")) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).sso.passwordComplexity
                     } else {
@@ -2690,10 +3014,7 @@ Function Request-SsoAccountLockout {
 		if (Test-VCFConnection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey("policyFile")) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).sso.accountLockout
                     } else {
@@ -3261,10 +3582,7 @@ Function Request-VcenterPasswordExpiration {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).vcenterServer.passwordExpiration
                     } else {
@@ -3383,10 +3701,7 @@ Function Request-VcenterPasswordComplexity {
                         if (Test-vSphereConnection -server $($vcfVcenterDetails.fqdn)) {
                             if (Test-vSphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
                                 if ($drift) {
-                                    $version = ""
-                                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                                        $version = $Matches[0]
-                                    } 
+                                    $version = Get-VCFManager -version
                                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                                         Get-LocalPasswordComplexity -version $version -vmName ($vcfVcenterDetails.fqdn.Split("."))[-0] -guestUser $vcfVcenterDetails.root -guestPassword $vcfVcenterDetails.rootPass -product vcenterServerLocal -drift -reportPath $reportPath -policyFile $policyFile
                                     } else {
@@ -3492,10 +3807,7 @@ Function Request-VcenterAccountLockout {
                         if (Test-vSphereConnection -server $($vcfVcenterDetails.fqdn)) {
                             if (Test-vSphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
                                 if ($drift) {
-                                    $version = ""
-                                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                                        $version = $Matches[0]
-                                    } 
+                                    $version = Get-VCFManager -version
                                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                                         Get-LocalAccountLockout -version $version -vmName ($vcfVcenterDetails.fqdn.Split("."))[-0] -guestUser $vcfVcenterDetails.root -guestPassword $vcfVcenterDetails.rootPass -product vcenterServerLocal -drift -reportPath $reportPath -policyFile $policyFile
                                     } else {
@@ -3878,10 +4190,7 @@ Function Request-VcenterRootPasswordExpiration {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).vcenterServerLocal.passwordExpiration
                     } else {
@@ -4483,10 +4792,7 @@ Function Request-NsxtManagerPasswordExpiration {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).nsxManager.passwordExpiration
                     } else {
@@ -4583,10 +4889,7 @@ Function Request-NsxtManagerPasswordComplexity {
 	Try {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {   
-                $version = ""
-                if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                    $version = $Matches[0]
-                }             
+                $version = Get-VCFManager -version
                 if ($drift) { 
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).nsxManager.passwordComplexity
@@ -4740,10 +5043,7 @@ Function Request-NsxtManagerAccountLockout {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).nsxManager.accountLockout
                     } else {
@@ -5567,10 +5867,7 @@ Function Request-NsxtEdgePasswordExpiration {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).nsxManager.passwordExpiration
                     } else {
@@ -5669,10 +5966,7 @@ Function Request-NsxtEdgePasswordComplexity {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).nsxEdge.passwordComplexity
                     } else {
@@ -5790,10 +6084,7 @@ Function Request-NsxtEdgeAccountLockout {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).nsxEdge.accountLockout
                     } else {
@@ -6530,10 +6821,7 @@ Function Request-EsxiPasswordExpiration {
 		if (Test-VCFConnection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey("policyFile")) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).esxi.passwordExpiration
                     } else {
@@ -6655,10 +6943,7 @@ Function Request-EsxiPasswordComplexity {
 		if (Test-VCFConnection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version 
                     if ($PsBoundParameters.ContainsKey("policyFile")) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).esxi.passwordComplexity
                     } else {
@@ -6784,10 +7069,7 @@ Function Request-EsxiAccountLockout {
 		if (Test-VCFConnection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey("policyFile")) {
                         $requiredConfig = (Get-PasswordPolicyConfig -version $version -reportPath $reportPath -policyFile $policyFile ).esxi.accountLockout
                     } else {
@@ -8460,10 +8742,7 @@ Function Request-LocalUserPasswordExpiration {
         if (Test-VCFConnection -server $server) {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if ($drift) {
-                    $version = ""
-                    if(((Get-VCFManager).version) -match "\d+\.\d+\.\d+") {
-                        $version = $Matches[0]
-                    } 
+                    $version = Get-VCFManager -version
                     if ($PsBoundParameters.ContainsKey('policyFile')) {
                         $command = '(Get-PasswordPolicyConfig  -version $version -reportPath $reportPath -policyFile $policyFile ).' + $product + '.passwordExpiration'
                     } else {
@@ -8789,7 +9068,7 @@ Function Publish-PasswordRotationPolicy {
                     # Otherwise, return the results as HTML.
                     # $passwordRotationObject = $passwordRotationObject | Sort-Object 'Workload Domain', 'System', 'Resource', 'Type', 'User' | ConvertTo-Html -Fragment -PreContent 
                     # Return the results as HTML but create an anchor for each resource type.
-                    $passwordRotationObject = $passwordRotationObject | ConvertTo-Html -Fragment -PreContent "<a id=$($resourceName.ToLower() -replace ' ', '-')-password-rotation></a><h3>$($resourceName) - Password Rotation</h3>" -As Table
+                    $passwordRotationObject = $passwordRotationObject | ConvertTo-Html -Fragment -PreContent "<a id=$($resourceName.ToLower() -replace ' ', '-')-password-rotation></a><h3>$($resourceName)</h3>" -As Table
                     $passwordRotationObject = Convert-CssClassStyle -htmldata $passwordRotationObject
                     $passwordRotationObject
                 }
@@ -8953,6 +9232,16 @@ Function Request-PasswordRotationPolicy {
                         $message = 'Password is expired.'
                         $alert = 'RED'   
                     }
+
+                    try {
+                        $nextSchedule = [DateTime]::ParseExact($nextSchedule, 'yyyy-MM-ddTHH:mm:ss.fffZ', [System.Globalization.CultureInfo]::InvariantCulture)
+                    } catch {                                               
+                    } 
+                    $passwordRotationExpiryDate = $passwordRotation.expiry.expiryDate
+                    try {
+                        $passwordRotationExpiryDate = [DateTime]::ParseExact($passwordRotation.expiry.expiryDate, 'yyyy-MM-ddTHH:mm:ss.fffZ', [System.Globalization.CultureInfo]::InvariantCulture)
+                    } catch {                                             
+                    } 
     
                     [PSCustomObject]@{
                         'Workload Domain' = $passwordRotation.resource.domainName
@@ -8962,7 +9251,7 @@ Function Request-PasswordRotationPolicy {
                         'User'            = $passwordRotation.username
                         'Frequency Days'  = $frequencyInDays
                         'Next Schedule'   = $nextSchedule
-                        'Expiration'      = $passwordRotation.expiry.expiryDate
+                        'Expiration'      = $passwordRotationExpiryDate
                         'Connection'      = $passwordRotation.expiry.connectivityStatus
                         'Status'          = $passwordRotation.expiry.status
                         'Alert'           = $alert

--- a/docs/documentation/functions/Invoke-PasswordRotationManager.md
+++ b/docs/documentation/functions/Invoke-PasswordRotationManager.md
@@ -1,0 +1,191 @@
+# Invoke-PasswordRotationManager
+
+## Synopsis
+
+Generates a Password Rotation Manager Report for a workload domain or all workload domains.
+
+## Syntax
+
+### All-WorkloadDomains
+
+```powershell
+Invoke-PasswordRotationManager -sddcManagerFqdn <String> -sddcManagerUser <String> -sddcManagerPass <String> -sddcRootPass <String> -reportPath <String> [-allDomains] [-darkMode] [-json] [<CommonParameters>]
+```
+
+### Specific-WorkloadDomain
+
+```powershell
+Invoke-PasswordRotationManager -sddcManagerFqdn <String> -sddcManagerUser <String> -sddcManagerPass <String> -sddcRootPass <String> -reportPath <String> -workloadDomain <String> [-darkMode] [-json] [<CommonParameters>]
+```
+
+## Description
+
+The `Invoke-PasswordRotationManager` generates a Password Rotation Manager Report for a workload domain or all workload domains.
+
+## Examples
+
+### Example 1
+
+```powershell
+Invoke-PasswordRotationManager -sddcManagerFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerUser admin@local -sddcManagerPass VMw@re1!VMw@re1! -reportPath "F:\Reporting" -darkMode -allDomains        
+```
+
+This example runs a password rotation report for all workload domains within an SDDC Manager instance.
+
+### Example 2
+
+```powershell
+Invoke-PasswordRotationManager -sddcManagerFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerUser admin@local -sddcManagerPass VMw@re1!VMw@re1!  -reportPath "F:\Reporting" -darkMode -workloadDomain sfo-w01
+```
+
+This example runs a password rotation report for a specific Workload Domain within an SDDC Manager instance.
+
+## Parameters
+
+### -sddcManagerFqdn
+
+The fully qualified domain name of the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -sddcManagerUser
+
+The username to authenticate to the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -sddcManagerPass
+
+The password to authenticate to the SDDC Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -sddcRootPass
+
+The password for the SDDC Manager appliance root account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -reportPath
+
+The path to save the report to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -allDomains
+
+Switch to run the report for all workload domains.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: All-WorkloadDomains
+Aliases:
+
+Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -workloadDomain
+
+Switch to run the report for a specific workload domain.
+
+```yaml
+Type: String
+Parameter Sets: Specific-WorkloadDomain
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -darkMode
+
+Switch to use dark mode for the report.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -json
+
+Switch to output the report in JSON format.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
     - General:
       - Get-PasswordPolicyDefault: documentation/functions/Get-PasswordPolicyDefault.md
       - Invoke-PasswordPolicyManager: documentation/functions/Invoke-PasswordPolicyManager.md
+      - Invoke-PasswordRotationManager: documentation/functions/Invoke-PasswordRotationManager.md
       - Request-LocalUserPasswordExpiration: documentation/functions/Request-LocalUserPasswordExpiration.md
       - Start-PasswordPolicyConfig: documentation/functions/Start-PasswordPolicyConfig.md
       - Test-VcfPasswordManagementPrereq: documentation/functions/Test-VcfPasswordManagementPrereq.md


### PR DESCRIPTION
### Summary

Added `Invoke-PasswordRotationManager`, `Save-ClarityReportNavigationForRotation` and `Set-CreateReportDirectoryRotation` cmdlets and updated `Publish-PasswordRotationPolicy` cmdlet to generate report for password rotation settings for accounts managed by SDDC Manager in HTML or JSON format. Results can be filtered by workload domain.

Updated `Invoke-PasswordPolicyManager` ,  `Get-PasswordPolicyDefault`, `Get-PasswordPolicyConfig`, `Request-SddcManagerPasswordComplexity`, `Request-SddcManagerAccountLockout`, `Request-SsoAccountLockout`, `Request-VcenterPasswordExpiration`, `Request-VcenterPasswordComplexity`, `Request-VcenterAccountLockout`, `Request-VcenterRootPasswordExpiration`, `Request-NsxtManagerPasswordExpiration`, `Request-NsxtManagerPasswordComplexity`, `Request-NsxtManagerAccountLockout`, `Request-NsxtEdgePasswordExpiration`, `Request-NsxtEdgePasswordComplexity`, `Request-NsxtEdgeAccountLockout`, `Request-EsxiPasswordExpiration`, `Request-EsxiPasswordComplexity`, `Request-EsxiAccountLockout` and `Request-LocalUserPasswordExpiration` cmdlets for simplifying logic for reading version information with PowerVCF v2.4.0 (pending release).

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [X] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

 Closes #105 
 Closes #109

### Additional Information

Though reporting structure has a mention of 'Aria' suite components. It it yet to be qualified with VCF 5.1.
