### PR TITLE
fix: `Request-VcenterPasswordComplexity` not providing an output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 > Release Date: Unreleased
 
+Bugfix:
+
+- Fixed returning of the object in `Request-VcenterPasswordComplexity` cmdlet. [GH-157](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/157)
+
 Enhancements:
 
 - Added support in `Request-NsxtEdgePasswordComplexity` to retrieve the password complexity policy from an non-managed NSX Edge Node. [GH-148](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/148)

--- a/VMware.CloudFoundation.PasswordManagement.psd1
+++ b/VMware.CloudFoundation.PasswordManagement.psd1
@@ -11,7 +11,7 @@
     RootModule = '.\VMware.CloudFoundation.PasswordManagement.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.7.1.1003'
+    ModuleVersion = '1.7.1.1004'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/VMware.CloudFoundation.PasswordManagement.psm1
+++ b/VMware.CloudFoundation.PasswordManagement.psm1
@@ -4045,6 +4045,7 @@ Function Request-VcenterPasswordComplexity {
                                         $VcenterLocalPasswordComplexityPolicy += $VcenterLocalPasswordComplexityObject
                                 }
                             }
+                            return $VcenterLocalPasswordComplexityPolicy
                         }
                     }
                 } else {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->
 Fixed output for `Request-VcenterPasswordComplexity`.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

```powershell
PS C:\GitHubPublic\VMware.CloudFoundation.PasswordManagement\VMware.CloudFoundation.PasswordManagement> Request-VcenterPasswordComplexity -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass -domain $sddcDomainName

Workload Domain : sfo-m01
System          : sfo-m01-vc01.sfo.rainpole.io
Min Length      : 6
Min Lowercase   : -1
Min Uppercase   : -1
Min Numerical   : -1
Min Special     : -1
Min Unique      : 4
History         : 5
Alert           : GREEN
Message         : SDDC Manager is able to rotate the password.
```

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->
 Closes #156 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
