### PR TITLE
fix: add `VMware.PowerCLI` module to `requiredModules`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,10 +188,16 @@ jobs:
               Set-Location '/home/runner/.local/share/powershell/Modules/' 
               foreach ($module in $requiredModules) {
                   $requiredModuleName = $module.ModuleName
-                  New-Item $requiredModuleName -ItemType Directory
-                  Write-Output "INFO: Performing workaround for github.com/PowerShell/PowerShell/issues/7722."
-                  Write-Output "INFO: Creating placeholder manifest for $requiredModuleName at $((Get-Location).Path)/$requiredModuleName/$requiredModuleName.psd1"
-                  New-Item "./$requiredModuleName/$requiredModuleName.psd1" -ItemType File
+                  if ($requiredModuleName -eq 'VMware.PowerCLI') {
+                    Write-Output "INFO: Installing version defined in the manifest from the PowerShell Gallery."
+                    Uninstall-Module -Name VMware.PowerCLI -AllVersions -Force
+                    Install-Module -Name VMware.PowerCLI -RequiredVersion $module.RequiredVersion -Force
+                  } else {
+                    New-Item $requiredModuleName -ItemType Directory
+                    Write-Output "INFO: Performing workaround for github.com/PowerShell/PowerShell/issues/7722."
+                    Write-Output "INFO: Creating placeholder manifest for $requiredModuleName at $((Get-Location).Path)/$requiredModuleName/$requiredModuleName.psd1"
+                    New-Item "./$requiredModuleName/$requiredModuleName.psd1" -ItemType File
+                  }
               }
           } else {
               Write-Output "INFO: No module dependencies were found."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
           Set-PSRepository psgallery -InstallationPolicy trusted
           Write-Output "INFO: Installing module 'VMware.vSphere.SsoAdmin' from PSGallery."
           Install-Module -Name VMware.vSphere.SsoAdmin -confirm:$false -Force
+          Write-Output "INFO: Installing module 'VMware.PowerCLI' from PSGallery."
+          Install-Module -Name VMware.PowerCLI -confirm:$false -Force
           $moduleManifest = (Get-ChildItem -Path $env:GITHUB_WORKSPACE -Filter *.psd1).Name
           if ($moduleManifest) {
               Write-Output "SUCCESS: Manifest '$moduleManifest' found in '$env:GITHUB_WORKSPACE'."
@@ -36,7 +38,7 @@ jobs:
           Write-Output "INFO: Reading module manifest '$moduleManifest'."
           $moduleManifestData = Import-PowerShellDataFile -Path $moduleManifest
           $requiredModules = $moduleManifestData.RequiredModules
-          $requiredModules = $requiredModules | Where-Object { $_.ModuleName -ne 'VMware.vSphere.SsoAdmin' }
+          $requiredModules = $requiredModules | Where-Object { $_.ModuleName -ne 'VMware.vSphere.SsoAdmin' -and $_.ModuleName -ne 'VMware.PowerCLI'}
           Write-Output "INFO: Required modules are $($requiredModules.ModuleName -join ', ')." 
           foreach ($module in $requiredModules) {
             $requiredModuleName = $module.ModuleName

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Enhancement:
 Bugfix:
 
 - Fix for missing account lockout policy data for SDDC Manager and vCenter Server. [GH-160](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/160)
+- Fix for `VMware.PowerCLI` module name not being mentioned in the required modules list of the manifest file. [GH-170](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/170)
 
 ## v1.7.1
 

--- a/VMware.CloudFoundation.PasswordManagement.psd1
+++ b/VMware.CloudFoundation.PasswordManagement.psd1
@@ -11,7 +11,7 @@
     RootModule        = '.\VMware.CloudFoundation.PasswordManagement.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.7.2.1002'
+    ModuleVersion     = '1.7.2.1003'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -62,6 +62,10 @@
         @{
             ModuleName    = 'PowerValidatedSolutions';
             ModuleVersion = '2.9.0'
+        }
+        @{
+            ModuleName    = 'VMware.PowerCLI';
+            ModuleVersion = '13.1.0'
         }
     )
 


### PR DESCRIPTION

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->
`VMware.PowerCLI` module name was not listed in the required modules list of the manifest file. Added the same.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->
   Closes #169 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
