### PR TITLE
fix: update `Update-VcenterRootPasswordExpiration` empty email handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ Breaking Change:
 
 Enhancement:
 
-- Added 5.1.1.0 to  `Get-PasswordPolicyDefault` and `Get-PasswordPolicyConfig` to support VMware Cloud Foundation 5.1.1. [GH-164](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/164)
+- Added 5.1.1.0 to `Get-PasswordPolicyDefault` and `Get-PasswordPolicyConfig` to support VMware Cloud Foundation 5.1.1. [GH-164](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/164)
 - Enhanced `Get-PasswordPolicyDefault` to show summary in easily readable format. [GH-178](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/178)
 
 Bugfix:
 
 - Fixed missing account lockout policy data for SDDC Manager and vCenter Server. [GH-160](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/160)
-- Fixed `VMware.PowerCLI` module name not being mentioned in the required modules list of the manifest file. [GH-170](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/170)
+- Fixed `VMware.PowerCLI` module name not being added in the required modules list of the manifest file. [GH-170](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/170)
 - Fixed `Test-VcfPasswordManagementPrereq` not working while multiple module versions were present. [GH-174](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/174)
+- Fixed `Update-VcenterRootPasswordExpiration` to handle empty email string. [GH-177](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/177)
 
 Chore:
 
@@ -61,7 +62,7 @@ Bugfix:
 
 Enhancement:
 
-- Added 5.1.0.0 to  `Get-PasswordPolicyDefault` and `Get-PasswordPolicyConfig` to support VMware Cloud Foundation 5.1. [GH-130](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/130)
+- Added 5.1.0.0 to `Get-PasswordPolicyDefault` and `Get-PasswordPolicyConfig` to support VMware Cloud Foundation 5.1. [GH-130](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/130)
 - Updated `Update-SddcManagerPasswordComplexity`, `Update-SddcManagerAccountLockout`, and `Update-vCenterAccountLockout` cmdlet to support VMware Cloud Foundation 5.1 by addressing changes in Photon OS 4 for vCenter Server 8.0.2 and SDDC Manager 5.1. [GH-130](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/130)
 
 Documentation:
@@ -125,7 +126,7 @@ Bugfix:
 - Updated `Get-PasswordPolicyDefault` to include support for VMware Cloud Foundation 4.5.2. [GH-91](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/91)
 - Updated `Get-PasswordPolicyConfig` to include support for VMware Cloud Foundation 4.5.2. [GH-91](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/91)
 - Updated `Get-PasswordPolicyDefault` to include support for VMware Cloud Foundation 4.5.0. [GH-71](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/71)
-- Updated `Get-PasswordPolicyConfig` to include support for  VMware Cloud Foundation 4.5.0. [GH-71](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/71)
+- Updated `Get-PasswordPolicyConfig` to include support for VMware Cloud Foundation 4.5.0. [GH-71](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/71)
 - Updated `Invoke-PasswordPolicyManager` to address version support updates and JSON file depth handling. [GH-71](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/71)
 - Updated `Request-NsxtEdgePasswordExpiration` to pass the `-transportNodeId` parameter to `Get-NsxtApplianceUser` to retrieve the NSX Edge node ID. [GH-76](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/76)
 - Updated `Update-NsxtEdgePasswordExpiration` to pass the `-transportNodeId` parameter to `Get-NsxtApplianceUser` and `Set-NsxtApplianceUserExpirationPolicy` to retrieve the NSX Edge node ID. [GH-76](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/76)
@@ -214,7 +215,7 @@ Bugfix:
 - Fixed drift option error for `Publish-VcenterLocalAccountLockout`. [GH-34](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/34)
 - Fixed drift option error for `Publish-VcenterLocalPasswordExpiration`. [GH-34](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/34)
 - Fixed drift option error for `Publish-VcenterLocalPasswordComplexity`. [GH-34](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/34)
-- Handled empty email string values and "0" value for WSADirectory feilds coming from JSON file  `Test-PasswordPolicyConfig`. [GH-36](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/36)
+- Handled empty email string values and "0" value for WSADirectory feilds coming from JSON file `Test-PasswordPolicyConfig`. [GH-36](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/36)
 - Corrected Description in `Start-PasswordPolicyConfig`. [GH-36](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-password-management/pull/36)
 
 Enhancement:


### PR DESCRIPTION
### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->
 Fixed `Update-VcenterRootPasswordExpiration` to handle empty email string parameter

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->
Closes #171 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
